### PR TITLE
Debit credit cards

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bpapp-mock "0.0.1-SNAPSHOT"
+(defproject bpapp-mock "0.1.0"
   :description "Simulador del API de servicios financieros de Banco del Pacífico"
   :url "http://github.com/datil/bpapp-mock"
   :license {:name "Eclipse Public License"

--- a/resources/responses.edn
+++ b/resources/responses.edn
@@ -84,14 +84,15 @@
                                     :type "10",
                                     :type-label "Cuenta de Ahorros"
                                     :customer-name "AVILES CHAVEZ ROSA",
-                                    :max-amount "4,999.00"}
-                                   {:description "Visa 4324XXXXXXXX1207"
-                                    :id "167"
-                                    :number "4324XXXXXXXX1207"
-                                    :type "1"
-                                    :type-label "Visa"
-                                    :customer-name "MARTINEZ HEISENBERG"
-                                    :max-amount ""}]}
+                                    :max-amount "4,999.00"}]}
+ :debit-credit-cards {:debit-credit-cards [{:description "Visa 4324XXXXXXXX1207"
+                                            :id "167"
+                                            :number "4324XXXXXXXX1207"
+                                            :type "1"
+                                            :type-label "Visa"
+                                            :customer-name "MARTINEZ HEISENBERG"
+                                            :max-amount ""}]}
+
  :credit-accounts {:credit-accounts [{:description "1064385205 Mi Cuenta EMELEC ",
                                       :id "1",
                                       :number "1064385205",

--- a/src/bpapp_mock/service.clj
+++ b/src/bpapp_mock/service.clj
@@ -33,6 +33,7 @@
      ["/credit-accounts" {:get [:credit-accounts mock-response]}]
      ["/customers" {:get [:customers mock-response]}]
      ["/debit-accounts" {:get [:debit-accounts mock-response]}]
+     ["/debit-credit-cards" {:get [:debit-credit-cards mock-response]}]
      ["/detectid-images" {:get [:detectid-images mock-response]}]
      ["/water-services" {:get [:water-services mock-response]}
       ["/:account-id" {:get [:water-services-account mock-response]

--- a/test/bpapp_mock/debit_credit_cards_test.clj
+++ b/test/bpapp_mock/debit_credit_cards_test.clj
@@ -1,0 +1,20 @@
+(ns bpapp-mock.debit-credit-cards-test
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
+            [io.pedestal.test :refer :all]
+            [io.pedestal.http :as bootstrap]
+            [bpapp-mock.service :as service]
+            [bpapp-mock.util :as u]
+            [bpapp-mock.test-utils :refer [json-body content-type]]))
+
+(def service
+  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+
+(def rsc (u/load-resource "responses.edn"))
+
+;;; /debit-credit-cards
+
+(deftest returns-debit-accounts-test
+  (is (=
+       (json-body (response-for service :get "/debit-credit-cards"))
+       (:debit-credit-cards rsc))))


### PR DESCRIPTION
Las tarjetas de crédito matriculadas como medio de pago de servicios ahora se muestran en un endpoint separado de las cuentas. El objetivo es no afectar los servicios que ya utilizan las cuentas que aparecen en /debit-accounts y que no soportan pago con tarjeta de crédito.
